### PR TITLE
Update keepbook input to 0.4.17

### DIFF
--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -1408,11 +1408,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781819042,
-        "narHash": "sha256-1rVGLxy5GIlIqRUvjlqGd9Tjkeo+1z38OQABVk3h+hY=",
+        "lastModified": 1781822941,
+        "narHash": "sha256-9biXcoMW/Gdh7HBbXBpH2tt33xh8Zvhsm9wuHVEcpXE=",
         "owner": "colonelpanic8",
         "repo": "keepbook",
-        "rev": "831e110cfe75f43e245fe922bb588e3121818c2a",
+        "rev": "815a26ff7efad93fd6fa5395af177c7c5d86068f",
         "type": "github"
       },
       "original": {

--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -1408,11 +1408,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781484243,
-        "narHash": "sha256-8MORYJdWu16cvjbdpUkql1CKU+49UYEBimhAeNHrba4=",
+        "lastModified": 1781819042,
+        "narHash": "sha256-1rVGLxy5GIlIqRUvjlqGd9Tjkeo+1z38OQABVk3h+hY=",
         "owner": "colonelpanic8",
         "repo": "keepbook",
-        "rev": "6a3381159a60761ac65ab0a1ebfd82762feae1b7",
+        "rev": "831e110cfe75f43e245fe922bb588e3121818c2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- updates the NixOS flake lock for `keepbook` to commit `815a26ff7efad93fd6fa5395af177c7c5d86068f`
- brings the dotfiles keepbook input to the `0.4.17` release-prep branch from colonelpanic8/keepbook#5

## Validation

- `nix eval --impure --expr 'let flake = builtins.getFlake "git+file:///srv/dotfiles?dir=nixos"; in flake.inputs.keepbook.packages.x86_64-linux.keepbook.version' --raw --extra-experimental-features 'nix-command flakes'` -> `0.4.17`\n- `nix eval .#nixosConfigurations.ryzen-shine.config.networking.hostName --raw` -> `ryzen-shine`\n- `nix eval .#nixosConfigurations.ryzen-shine.config.myModules."keepbook-sync".enable` -> `true`\n