### PR TITLE
nix: install gmcli on NixOS and nix-darwin

### DIFF
--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -349,6 +349,27 @@
         "type": "github"
       }
     },
+    "gmcli": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783809746,
+        "narHash": "sha256-vzNMRRQqRvi3tjbZ5jKyb4BfeCi/lLtWDTMOHcfMRH0=",
+        "owner": "colonelpanic8",
+        "repo": "gmcli",
+        "rev": "54c9f47ea9e241e440f30f936804dafcd89c85ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "colonelpanic8",
+        "ref": "agent/json-archive-export",
+        "repo": "gmcli",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -623,6 +644,7 @@
         "flake-utils": "flake-utils_3",
         "git-blame-rank": "git-blame-rank",
         "git-sync-rs": "git-sync-rs",
+        "gmcli": "gmcli",
         "home-manager": "home-manager_2",
         "homebrew-cask": "homebrew-cask",
         "homebrew-core": "homebrew-core",

--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -36,6 +36,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    gmcli = {
+      url = "github:colonelpanic8/gmcli?ref=agent/json-archive-export";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     codex-cli-nix = {
       # Default branch is `main` on GitHub (not `master`).
       url = "github:sadjow/codex-cli-nix/main";

--- a/nix-shared/system/essential.nix
+++ b/nix-shared/system/essential.nix
@@ -30,6 +30,7 @@
       };
   });
   coquiTtsStreamer = inputPackageOrNull "coqui-tts-streamer" "default";
+  gmcli = inputPackageOrNull "gmcli" "default";
   keepbook = inputs.keepbook.packages.${system}.keepbook.overrideAttrs (_: {
     # Upstream checks currently depend on TS artifacts that are not built in Nix.
     doCheck = false;
@@ -85,6 +86,7 @@
     ])
     ++ lib.optionals (!isJayLenovo) [pkgs.bazel]
     ++ lib.optionals (coquiTtsStreamer != null) [coquiTtsStreamer]
+    ++ lib.optionals (gmcli != null) [gmcli]
     ++ lib.optionals (builtins.hasAttr "git-sync-rs" pkgs) [pkgs.git-sync-rs]);
 
   linuxOnly = with pkgs; [

--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -713,6 +713,27 @@
         "type": "github"
       }
     },
+    "gmcli": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783809746,
+        "narHash": "sha256-vzNMRRQqRvi3tjbZ5jKyb4BfeCi/lLtWDTMOHcfMRH0=",
+        "owner": "colonelpanic8",
+        "repo": "gmcli",
+        "rev": "54c9f47ea9e241e440f30f936804dafcd89c85ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "colonelpanic8",
+        "ref": "agent/json-archive-export",
+        "repo": "gmcli",
+        "type": "github"
+      }
+    },
     "grub2-themes": {
       "inputs": {
         "nixpkgs": [
@@ -2050,6 +2071,7 @@
         "git-blame-rank": "git-blame-rank",
         "git-ignore-nix": "git-ignore-nix",
         "git-sync-rs": "git-sync-rs",
+        "gmcli": "gmcli",
         "grub2-themes": "grub2-themes",
         "heroic-games-launcher": "heroic-games-launcher",
         "home-manager": "home-manager",

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -50,6 +50,11 @@
       };
     };
 
+    gmcli = {
+      url = "github:colonelpanic8/gmcli?ref=agent/json-archive-export";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     keepbook = {
       url = "github:colonelpanic8/keepbook";
       inputs = {


### PR DESCRIPTION
## Summary

- add the gmcli flake as an input to both the NixOS and nix-darwin flakes
- make the gmcli package follow each configuration's existing nixpkgs input
- install gmcli through the shared essential system package list
- lock both configurations to the tested gmcli revision

## Why

gmcli now publishes a cross-platform Nix flake. Installing it from the shared essential package module makes the CLI available by default on both NixOS and nix-darwin without duplicating its build definition.

This PR currently follows `colonelpanic8/gmcli:agent/json-archive-export`, which is the head of [fdsouvenir/gmcli#2](https://github.com/fdsouvenir/gmcli/pull/2). It can be switched to upstream after that PR merges.

## Validation

- formatted all changed Nix files with Alejandra
- evaluated `mac-demarco-mini` and confirmed `gmcli` is in `environment.systemPackages`
- built the locked aarch64-darwin gmcli package with its Go tests enabled
- evaluated gmcli derivations for both x86_64-linux and aarch64-linux

Full NixOS host evaluation is not available from this Apple Silicon host because the existing NixOS flake realizes Linux-only patch derivations during evaluation.
