### PR TITLE
Add T3 Code to NixOS

### DIFF
--- a/nixos/code.nix
+++ b/nixos/code.nix
@@ -127,6 +127,7 @@ in
         inputs.gmcli.packages.${pkgs.stdenv.hostPlatform.system}.default
         inputs.lastfm-edit.packages.${pkgs.stdenv.hostPlatform.system}.scrobble-scrubber-app
         opencode
+        t3code
 
         # MCP
         github-mcp-server

--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -2087,6 +2087,7 @@
         "railbird-secrets": "railbird-secrets",
         "rlru": "rlru",
         "systems": "systems_6",
+        "t3code-nix": "t3code-nix",
         "vscode-server": "vscode-server",
         "xmonad": "xmonad_2",
         "xmonad-contrib": "xmonad-contrib_2",
@@ -2251,6 +2252,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "t3code-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783865433,
+        "narHash": "sha256-R/2UilYyaOqwCZ+C15VPSzrl73yXBmguT/ac/nXGIUw=",
+        "owner": "omarcresp",
+        "repo": "t3code-flake",
+        "rev": "99b3a112b35345593b0bff31617e13f1c7389338",
+        "type": "github"
+      },
+      "original": {
+        "owner": "omarcresp",
+        "repo": "t3code-flake",
         "type": "github"
       }
     },

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -290,6 +290,11 @@
       };
     };
 
+    t3code-nix = {
+      url = "github:omarcresp/t3code-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     claude-desktop = {
       url = "github:aaddrick/claude-desktop-debian";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nixos/justfile
+++ b/nixos/justfile
@@ -9,6 +9,10 @@ bump-claude-codex *args:
 	PATH=/run/current-system/sw/bin:/nix/var/nix/profiles/system/sw/bin:/etc/profiles/per-user/root/bin:/usr/bin:/bin nix flake update codex-cli-nix codex-desktop-linux claude-code-nix claude-desktop
 	just switch {{args}}
 
+bump-t3code *args:
+	PATH=/run/current-system/sw/bin:/nix/var/nix/profiles/system/sw/bin:/etc/profiles/per-user/root/bin:/usr/bin:/bin nix flake update t3code-nix
+	just switch {{args}}
+
 populate-cachix cache="colonelpanic8-dotfiles" host=`hostname` *args:
 	store_path="$(nix build --no-link --print-out-paths ".#nixosConfigurations.{{host}}.config.system.build.toplevel" --impure --option warn-dirty false {{args}})" && cachix push {{cache}} "$store_path"
 

--- a/nixos/nix.nix
+++ b/nixos/nix.nix
@@ -110,10 +110,11 @@
         # (import ./nvidia-container-toolkit-overlay.nix)
         (import ./emacs-overlay.nix)
         (import ../nix-shared/overlays)
-        # Use codex and claude-code from dedicated flakes with cachix
+        # Use fast-moving agent tools from dedicated flakes.
         (final: prev: {
           codex = inputs.codex-cli-nix.packages.${prev.stdenv.hostPlatform.system}.default;
           claude-code = inputs.claude-code-nix.packages.${prev.stdenv.hostPlatform.system}.default;
+          t3code = inputs.t3code-nix.packages.${prev.stdenv.hostPlatform.system}.default;
           git-sync-rs = inputs.git-sync-rs.packages.${prev.stdenv.hostPlatform.system}.default;
           elegant-grub2-theme = final.callPackage ./packages/elegant-grub2-theme {};
           kef = final.callPackage ./packages/kef {};


### PR DESCRIPTION
## Summary

- add the auto-updating `omarcresp/t3code-flake` input
- expose its stable package as `pkgs.t3code`
- install T3 Code with the other system-wide agent tools
- add `just bump-t3code` for a targeted flake update and NixOS switch

## Why

Upstream T3 Code does not currently expose its own Nix flake, while the nixpkgs source recipe requires source and pnpm dependency hash updates. The selected package flake follows official release artifacts and refreshes frequently, matching the existing Codex and Claude packaging pattern.

## Verification

- built `nixosConfigurations.ryzen-shine.pkgs.t3code` from the clean commit
- confirmed version `0.0.28` and executable `bin/t3-code`
- evaluated the complete `ryzen-shine` system derivation
- applied the configuration successfully with `just switch`
- confirmed the active system exposes `t3-code`, its desktop entry, Codex, and Claude, with zero failed systemd units
