### PR TITLE
taffybar: propagate Claude reset window day

### DIFF
--- a/dotfiles/config/taffybar/flake.lock
+++ b/dotfiles/config/taffybar/flake.lock
@@ -136,11 +136,11 @@
         "xmonad-contrib": "xmonad-contrib"
       },
       "locked": {
-        "lastModified": 1784160414,
-        "narHash": "sha256-IX95KwDmorG+guyy/6mibP8zHNie+kw2E2MQNeKyOSE=",
+        "lastModified": 1784319122,
+        "narHash": "sha256-gv0LZMvOcA1yUPrHqyvMVgh447O29FoCi6JeUF/wzhE=",
         "ref": "refs/heads/master",
-        "rev": "648c2979dfdf4586d83a572c1e1315ffd602daa2",
-        "revCount": 2382,
+        "rev": "bfa8541fb58c8f13c0faea77f27802e6f33e2419",
+        "revCount": 2384,
         "type": "git",
         "url": "file:./dotfiles/config/taffybar/taffybar"
       },

--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -2317,11 +2317,11 @@
         "xmonad-contrib": "xmonad-contrib"
       },
       "locked": {
-        "lastModified": 1784160414,
-        "narHash": "sha256-IX95KwDmorG+guyy/6mibP8zHNie+kw2E2MQNeKyOSE=",
+        "lastModified": 1784319122,
+        "narHash": "sha256-gv0LZMvOcA1yUPrHqyvMVgh447O29FoCi6JeUF/wzhE=",
         "ref": "refs/heads/master",
-        "rev": "648c2979dfdf4586d83a572c1e1315ffd602daa2",
-        "revCount": 2382,
+        "rev": "bfa8541fb58c8f13c0faea77f27802e6f33e2419",
+        "revCount": 2384,
         "type": "git",
         "url": "file:./dotfiles/config/taffybar/taffybar"
       },


### PR DESCRIPTION
## Summary

- advance the vendored taffybar checkout to merged upstream PR taffybar/taffybar#689
- update the imalison-taffybar lockfile to the merged revision
- propagate the same revision through the NixOS lockfile

## Validation

- both lockfiles resolve taffybar revision `bfa8541fb58c8f13c0faea77f27802e6f33e2419`
- only the taffybar lock nodes and submodule pointer changed
- upstream targeted tests: 3 examples, 0 failures
- upstream `cabal build all` passed